### PR TITLE
Fix spelling mistake in .emacs

### DIFF
--- a/emacs
+++ b/emacs
@@ -14,7 +14,7 @@
  ;; custom-set-faces was added by Custom.
  ;; If you edit it by hand, you could mess it up, so be careful.
  ;; Your init file should contain only one such instance.
- ;; If there is more than one, they wosdfsfn't work right.
+ ;; If there is more than one, they won't work right.
  )
 ;(add-to-list 'custom-theme-load-path "~/.emacs.d/color-theme/themes/")
 ;(load-theme 'zenburn t)


### PR DESCRIPTION
This patch critically enhances the user experience of reading the .emacs
configuration file. It fixes an over two weeks old issue with the
spelling in a comment.
